### PR TITLE
rtk_bt: fix compile error with gcc 7.5

### DIFF
--- a/drivers/bluetooth/rtk_btusb.c
+++ b/drivers/bluetooth/rtk_btusb.c
@@ -1825,7 +1825,7 @@ void rtk_update_altsettings(patch_info *patch_entry, const unsigned char* org_co
 
     if (config->data_len != org_config_len - sizeof(struct rtk_bt_vendor_config))
     {
-        RTKBT_ERR("rtk_update_altsettings: config len(%x) is not right(%lx)", config->data_len, org_config_len-sizeof(struct rtk_bt_vendor_config));
+        RTKBT_ERR("rtk_update_altsettings: config len(%x) is not right(%zx)", config->data_len, org_config_len-sizeof(struct rtk_bt_vendor_config));
         return;
     }
 


### PR DESCRIPTION
drivers/bluetooth/rtk_btusb.c: In function 'rtk_update_altsettings':
include/linux/kern_levels.h:4:18: warning: format '%lx' expects argument of type 'long unsigned int', but argument 3 has type 'unsigned int' [-Wformat=]
error, forbidden warning:kern_levels.h:4

Change-Id: Id18ca5c8051891eb58d2623e9a01e274c930bf79